### PR TITLE
refactor: remove unused ToolContainer and ToolHead from skeleton comp…

### DIFF
--- a/frontend/scripts/generateTool.cjs
+++ b/frontend/scripts/generateTool.cjs
@@ -204,12 +204,6 @@ import ToolHead from "../../components/tool/ToolHead";
 
 const ${componentName}Skeleton: React.FC = () => {
   return (
-    <ToolContainer>
-      <ToolHead
-        name="${toolName}"
-        description="TODO: Add your tool description here. Make it compelling and SEO-friendly."
-      />
-      
       <div className="space-y-6">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <div className="space-y-4">
@@ -241,7 +235,6 @@ const ${componentName}Skeleton: React.FC = () => {
           </div>
         </div>
       </div>
-    </ToolContainer>
   );
 };
 


### PR DESCRIPTION
## Fix `generate new tool` loading issue

### Description

This MR fixes an issue where the **Generate New Tool** flow caused the page to load twice. The loading module was being initialized two times; that has been resolved so the module now initializes only once.

### Type of Change

*Delete options that are not relevant.*

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Style/UI improvements
* [ ] Code refactoring
* [ ] Performance improvements
* [ ] Test additions/updates

### Screenshots (if applicable)

Before (tool module initialized twice):
![Before](https://github.com/user-attachments/assets/011926e0-b2a9-4d68-9540-d8573fa6f586)


After (fixed — module initializes once):
![After](https://github.com/user-attachments/assets/17dd5f85-f40e-4c6b-a1c0-2561ce6fa994)

### Notes

* The root cause was duplicate initialization of the loading/tool module.
* Unit/manual tests were run to verify the loading screen appears only once.
